### PR TITLE
Add types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "release-it": "^14.11.6",
         "rollup": "^2.57.0",
         "rollup-plugin-babel": "^4.4.0",
+        "rollup-plugin-dts": "^4.0.1",
         "rollup-plugin-livereload": "^2.0.5",
         "rollup-plugin-svelte": "^7.1.0",
         "sirv-cli": "^1.0.14",
@@ -4842,6 +4843,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -6549,6 +6559,28 @@
         "rollup-pluginutils": "^2.8.1"
       }
     },
+    "node_modules/rollup-plugin-dts": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-4.0.1.tgz",
+      "integrity": "sha512-DNv5F8pro/r0Hkx3JWKRtJZocDnqXfgypoajeiaNq134rYaFcEIl/oas5PogD1qexMadVijsHyVko1Chig0OOQ==",
+      "dev": true,
+      "dependencies": {
+        "magic-string": "^0.25.7"
+      },
+      "engines": {
+        "node": ">=v12.22.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Swatinem"
+      },
+      "optionalDependencies": {
+        "@babel/code-frame": "^7.14.5"
+      },
+      "peerDependencies": {
+        "rollup": "^2.56.3",
+        "typescript": "^4.4.2"
+      }
+    },
     "node_modules/rollup-plugin-livereload": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/rollup-plugin-livereload/-/rollup-plugin-livereload-2.0.5.tgz",
@@ -7032,6 +7064,12 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
     },
     "node_modules/split-on-first": {
       "version": "1.1.0",
@@ -7545,6 +7583,20 @@
       "dev": true,
       "dependencies": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/ultron": {
@@ -12436,6 +12488,15 @@
       "integrity": "sha512-EIgv+QZ9r+814gjJj0Bt5vSLJLzswGmSUbUpbi9AIr/fsN2IWFBl2NucV9PAiek+U1STK468tEkxmVYUtuAN3g==",
       "dev": true
     },
+    "magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
+      }
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -13753,6 +13814,16 @@
         "rollup-pluginutils": "^2.8.1"
       }
     },
+    "rollup-plugin-dts": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-4.0.1.tgz",
+      "integrity": "sha512-DNv5F8pro/r0Hkx3JWKRtJZocDnqXfgypoajeiaNq134rYaFcEIl/oas5PogD1qexMadVijsHyVko1Chig0OOQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.14.5",
+        "magic-string": "^0.25.7"
+      }
+    },
     "rollup-plugin-livereload": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/rollup-plugin-livereload/-/rollup-plugin-livereload-2.0.5.tgz",
@@ -14104,6 +14175,12 @@
           "peer": true
         }
       }
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
     },
     "split-on-first": {
       "version": "1.1.0",
@@ -14509,6 +14586,13 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "dev": true,
+      "peer": true
     },
     "ultron": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "svelte": "src/web3-store.js",
+  "types": "dist/svelte-web3.d.ts",
   "license": "MIT",
   "repository": "clbrge/svelte-web3",
   "author": {
@@ -20,6 +21,7 @@
     "release-it": "^14.11.6",
     "rollup": "^2.57.0",
     "rollup-plugin-babel": "^4.4.0",
+    "rollup-plugin-dts": "^4.0.1",
     "rollup-plugin-livereload": "^2.0.5",
     "rollup-plugin-svelte": "^7.1.0",
     "sirv-cli": "^1.0.14",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,5 @@
+import dts from "rollup-plugin-dts";
+
 export default [
   {
     input: "./src/web3-store.js",
@@ -5,5 +7,10 @@ export default [
       { file: "dist/index.mjs", format: "es" },
       { file: "dist/index.js", format: "umd", name: "web3store" },
     ]
+  },
+  {
+    input: "./src/svelte-web3.d.ts",
+    output: [{ file: "dist/svelte-web3.d.ts", format: "es" }],
+    plugins: [dts()],
   },
 ]

--- a/src/svelte-web3.d.ts
+++ b/src/svelte-web3.d.ts
@@ -1,0 +1,129 @@
+import { Readable } from "svelte/store";
+import Web3 from "web3";
+
+declare module "svelte-web3" {
+    /**
+     * JavaScript CAIP-2 representation object.
+     * @see https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md
+     */
+    interface ChainData {
+        name: string;
+        chain: string;
+        network: string;
+        rpc: string[];
+        faucets: string[];
+        nativeCurrency: {
+            name: string;
+            symbol: string;
+            decimals: number;
+        };
+        infoURL: string;
+        shortName: string;
+        chainId: number;
+        networkId: number;
+        icon: string;
+        explorers: {
+            name: string;
+            url: string;
+            icon: string;
+            standard: string;
+        }[];
+    }
+
+    interface DefaultChainStore {
+        /**
+         * Enables a connection with the current window provider
+         * Note that your code need to be in browser context when setBrowserProvider is running.
+         * So you may want to use onMount when using Sapper or Sveltekit. Similarly, you cannot use setBrowserProvider in SSR context.
+         */
+        readonly setBrowserProvider(): Promise<void>;
+        /**
+         * To enable connection using a custom provider.
+         * @param provider An url string or a valid provider object (as returned by web3Modal or WalletConnect for example)
+         */
+        readonly setProvider(provider: string): Promise<void>;
+        /**
+         * Forces a disconnect (and event subscriptions from a provider)
+         */
+        readonly close(): Promise<void>;
+    }
+
+    // ---------- CUSTOM CHAIN STORE PROPERTIES ----------
+    interface ChainStore extends DefaultChainStore {
+        /**
+         * The whole Web3.js API. It must be references as `$web3` and not `web3` since it is a Svelte store.
+         * @see https://web3js.readthedocs.io/en/v1.5.2/web3.html
+         */
+        readonly web3: Readable<Web3>;
+        /**
+         * Current selected account address if connected, `null` otherwise.
+         */
+        readonly selectedAccount: Readable<string | null>;
+        /**
+         * `true` if connection to the provider was successful.
+         */
+        readonly connected: Readable<boolean>;
+        /**
+         * The current blockchain CAIP-2 data if connected, empty object otherwise.
+         */
+        readonly chainData: Readable<ChainData>;
+        /**
+         * The current chainId (if connected).
+         */
+        readonly chainId: Readable<number>;
+    }
+
+    // ---------- DEFAULT CHAIN STORE EXPORTS ----------
+    /**
+     * The main connection helper and derived Svelte stores
+     */
+    const defaultChainStore: DefaultChainStore;
+
+    /**
+     * The whole Web3.js API for the `defaultChainStore`. It must be references as `$web3` and not `web3` since it is a Svelte store.
+     * @see https://web3js.readthedocs.io/en/v1.5.2/web3.html
+     */
+    const web3: Readable<Web3>;
+    /**
+     * Current selected account address of the `defaultChainStore` if connected, `null` otherwise.
+     */
+    const selectedAccount: Readable<string | null>;
+    /**
+     * `true` if connection to the provider was successful for `defaultChainStore`.
+     */
+    const connected: Readable<boolean>;
+    /**
+     * The current blockchain CAIP-2 data of `defaultChainStore` if connected, empty object otherwise.
+     */
+    const chainData: Readable<ChainData>;
+    /**
+     * The current chainId of `defaultChainStore` if connected.
+     */
+    const chainId: Readable<number>;
+
+    /**
+     * This can be used to create several stores, each connected to different providers.
+     * This lets you manage different chains at the same time.
+     * @param name Unique name for the newly created store. The name `default` is used to create `defaultChainStore` so you shouldn't use it unless you want to override the default store.
+     */
+    function makeChainStore(name: string): ChainStore;
+    /**
+     * Retrieves the store without re-initializing the connection:
+     * @param name Name of the previously created store.
+     */
+    function getChainStore(name: string): ChainStore;
+
+    export {
+        ChainData,
+        DefaultChainStore,
+        ChainStore,
+        web3,
+        selectedAccount,
+        connected,
+        chainId,
+        chainData,
+        defaultChainStore,
+        makeChainStore,
+        getChainStore,
+    };
+}


### PR DESCRIPTION
Greetings, I've been experimenting with Svelte and this library and thought that types must be added sooner or later, so here it is...

Added `.d.ts` types complete with docstrings copied from the readme.

Even though `defaultChainStore` contains the properties listed in the `ChainStore`, the API is not intended to be used that way. Instead, the store properties are exported separately and not exposed from within `DefaultChainStore`. The properties are also included in `ChainStore` so that they can be accessed the way the [docs suggest,](https://github.com/clbrge/svelte-web3#simultaneous-multi-chain-usage)

Cheers