### PR TITLE
Update Types

### DIFF
--- a/src/svelte-web3.d.ts
+++ b/src/svelte-web3.d.ts
@@ -1,5 +1,8 @@
 import { Readable } from "svelte/store";
 import Web3 from "web3";
+import { provider } from "web3-core";
+import { AbiItem } from "web3-utils";
+import { ContractOptions, Contract } from "web3-eth-contract";
 
 declare module "svelte-web3" {
     /**
@@ -30,26 +33,19 @@ declare module "svelte-web3" {
         }[];
     }
 
-    interface DefaultChainStore {
+    interface ChainStore {
         /**
-         * Enables a connection with the current window provider
-         * Note that your code need to be in browser context when setBrowserProvider is running.
-         * So you may want to use onMount when using Sapper or Sveltekit. Similarly, you cannot use setBrowserProvider in SSR context.
-         */
-        readonly setBrowserProvider(): Promise<void>;
-        /**
-         * To enable connection using a custom provider.
+         * Enables a connection with the current window provider.
+         * Note that your code need to be in browser context when setProvider is running.
+         * So you may want to use onMount when using Sapper or Sveltekit.
          * @param provider An url string or a valid provider object (as returned by web3Modal or WalletConnect for example)
+         * @param index Select another account than the default when possible.
          */
-        readonly setProvider(provider: string): Promise<void>;
+        setProvider(provider?: provider, index?: string): Promise<void>;
         /**
          * Forces a disconnect (and event subscriptions from a provider)
          */
-        readonly close(): Promise<void>;
-    }
-
-    // ---------- CUSTOM CHAIN STORE PROPERTIES ----------
-    interface ChainStore extends DefaultChainStore {
+        disconnect(): Promise<void>;
         /**
          * The whole Web3.js API. It must be references as `$web3` and not `web3` since it is a Svelte store.
          * @see https://web3js.readthedocs.io/en/v1.5.2/web3.html
@@ -77,53 +73,75 @@ declare module "svelte-web3" {
     /**
      * The main connection helper and derived Svelte stores
      */
-    const defaultChainStore: DefaultChainStore;
+    const defaultEvmStores: ChainStore;
 
     /**
-     * The whole Web3.js API for the `defaultChainStore`. It must be references as `$web3` and not `web3` since it is a Svelte store.
+     * The whole Web3.js API for the `defaultEvmStores`. It must be references as `$web3` and not `web3` since it is a Svelte store.
      * @see https://web3js.readthedocs.io/en/v1.5.2/web3.html
      */
     const web3: Readable<Web3>;
     /**
-     * Current selected account address of the `defaultChainStore` if connected, `null` otherwise.
+     * Current selected account address of the `defaultEvmStores` if connected, `null` otherwise.
      */
     const selectedAccount: Readable<string | null>;
     /**
-     * `true` if connection to the provider was successful for `defaultChainStore`.
+     * `true` if connection to the provider was successful for `defaultEvmStores`.
      */
     const connected: Readable<boolean>;
     /**
-     * The current blockchain CAIP-2 data of `defaultChainStore` if connected, empty object otherwise.
+     * The current blockchain CAIP-2 data of `defaultEvmStores` if connected, empty object otherwise.
      */
     const chainData: Readable<ChainData>;
     /**
-     * The current chainId of `defaultChainStore` if connected.
+     * The current chainId of `defaultEvmStores` if connected.
      */
     const chainId: Readable<number>;
 
     /**
      * This can be used to create several stores, each connected to different providers.
      * This lets you manage different chains at the same time.
-     * @param name Unique name for the newly created store. The name `default` is used to create `defaultChainStore` so you shouldn't use it unless you want to override the default store.
+     * @param name Unique name for the newly created store. The name `default` is used to create `defaultEvmStores` so you shouldn't use it unless you want to override the default store.
      */
-    function makeChainStore(name: string): ChainStore;
+    function makeEvmStores(name: string): ChainStore;
     /**
      * Retrieves the store without re-initializing the connection:
      * @param name Name of the previously created store.
+     * @returns The store if connected, `null` otherwise.
      */
     function getChainStore(name: string): ChainStore;
 
+    /**
+     * You might want to access all chains CAIP-2 data directly without using the chainData store.
+     * In this case, use the getter allChainsData, it returns the list of all CAIP-2 data available.
+     */
+    const allChainsData: ChainData[];
+
+    /**
+     * Allows you to create a Svelte derived store of a web3.eth.Contract object instance.
+     * It takes the same parameters as a ̀new web3.eth.Contract` call.
+     * @param jsonInterface The contract ABI array
+     * @param address The contract address
+     * @param options The contract options
+     * @returns A Svelte derived store of a web3.eth.Contract object instance
+     */
+    function makeContractStore(
+        jsonInterface: AbiItem[],
+        address?: string,
+        options?: ContractOptions
+    ): Readable<Contract>;
+
     export {
         ChainData,
-        DefaultChainStore,
         ChainStore,
         web3,
         selectedAccount,
         connected,
         chainId,
         chainData,
-        defaultChainStore,
-        makeChainStore,
+        defaultEvmStores,
+        makeEvmStores,
         getChainStore,
+        allChainsData,
+        makeContractStore,
     };
 }


### PR DESCRIPTION
Updated the types following the new API changes.

I removed `defaultChainStore` even though it is still available as an export, we can add it back if needed.

I haven't had the time to properly test all the functionality so it'd be great if someone could also verify the work. 