### PR TITLE
Change to alwaysHex

### DIFF
--- a/src/stores.js
+++ b/src/stores.js
@@ -39,9 +39,8 @@ const getWindowEthereum = () => {
   }
 }
 
-// always get chainId as number
-const alwaysNumber = (n) =>
-  Web3.utils.isHex(n) ? Web3.utils.hexToNumber(n) : n
+// always get chainId as number EDIT: Always as hex
+const alwaysHex = (n) => (Web3.utils.isHex(n) ? n : Web3.utils.toHex(n))
 
 export const createStore = () => {
   const { emit, get, subscribe, assign, deleteAll } = proxied()
@@ -53,7 +52,7 @@ export const createStore = () => {
   }) => {
     // console.log('switch1193Provider', { accounts, chainId }, get('web3'), get('eipProvider'))
     if (!chainId) {
-      chainId = alwaysNumber(await get('web3').eth.getChainId())
+      chainId = alwaysHex(await get('web3').eth.getChainId())
     }
     if (!accounts) {
       accounts = await get('web3').eth.getAccounts()
@@ -76,7 +75,7 @@ export const createStore = () => {
 
   const accountsChangedHandler = (accounts) => switch1193Provider({ accounts })
   const chainChangedHandler = (chainId) =>
-    switch1193Provider({ chainId: alwaysNumber(chainId) })
+    switch1193Provider({ chainId: alwaysHex(chainId) })
   // TODO better error support ?
   const disconnectHandler = (error) => switch1193Provider({ error })
 
@@ -138,7 +137,7 @@ export const createStore = () => {
       return set1193Provider(provider, addressOrIndex)
     init()
     const web3 = new Web3(provider)
-    const chainId = alwaysNumber(await web3.eth.getChainId())
+    const chainId = alwaysHex(await web3.eth.getChainId())
     let accounts = []
     try {
       // not all provider support accounts


### PR DESCRIPTION
This seems to fix the issue when using web3js 4.x.x that its not possible to setProvider().

Error before gave this error:

```
Uncaught (in promise) s: Web3 validator found 1 error[s]:
value "1337" at "/0" must pass "hex" validation
    at c.validate (https://cdn.jsdelivr.net/npm/web3@latest/dist/web3.min.js:2:634195)
    at t.Web3Validator.validate (https://cdn.jsdelivr.net/npm/web3@latest/dist/web3.min.js:2:636887)
    at t.hexToNumber (https://cdn.jsdelivr.net/npm/web3@latest/dist/web3.min.js:2:589899)
    at alwaysNumber (http://127.0.0.1:5174/node_modules/.vite/deps/svelte-web3.js?v=d385d017:17695:60)
    at switch1193Provider (http://127.0.0.1:5174/node_modules/.vite/deps/svelte-web3.js?v=d385d017:17704:18)

```

You can reproduce in this repo: https://github.com/Crelde/svelte-web3-bug/tree/master

After the fix its possible to setProvider.

fixes #60