### PR TITLE
Fixes Error: [svelte-web3] no store named contracts

### DIFF
--- a/src/stores.js
+++ b/src/stores.js
@@ -41,6 +41,7 @@ const getWindowEthereum = () => {
 
 // always get chainId as number EDIT: Always as hex
 const alwaysHex = (n) => (Web3.utils.isHex(n) ? n : Web3.utils.toHex(n))
+// const alwaysHex = (n) => (Web3.utils.isHex(n) ? Web3.utils.hexToNumber(n) : n)
 
 export const createStore = () => {
   const { emit, get, subscribe, assign, deleteAll } = proxied()
@@ -211,7 +212,13 @@ const getData = (id) => {
   return noData
 }
 
-const subStoreNames = ['web3', 'selectedAccount', 'connected', 'chainId']
+const subStoreNames = [
+  'web3',
+  'selectedAccount',
+  'connected',
+  'chainId',
+  'contracts'
+]
 
 export const makeEvmStores = (name) => {
   const evmStore = (allStores[name] = createStore())

--- a/src/stores.js
+++ b/src/stores.js
@@ -39,9 +39,8 @@ const getWindowEthereum = () => {
   }
 }
 
-// always get chainId as number EDIT: Always as hex
+// always get chainId as hex (required since web3js 4.x.x)
 const alwaysHex = (n) => (Web3.utils.isHex(n) ? n : Web3.utils.toHex(n))
-// const alwaysHex = (n) => (Web3.utils.isHex(n) ? Web3.utils.hexToNumber(n) : n)
 
 export const createStore = () => {
   const { emit, get, subscribe, assign, deleteAll } = proxied()


### PR DESCRIPTION
fixes #62 
When making another set of evm stores it would also throw an error because the contracts "name" was not added to to "subStoreNames".

I found out since i am using another set of evmStores as an event watcher. Until making this change I was unable to use the extra set of stores.